### PR TITLE
bugfix: changed externals output arcive diretory permissions to docke…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ build_external: ## builds all libadore external libraries
 clean_external_cache: ## clean all libadore external library cache located in /var/tmp. Note: This is never done automatically and must be manually invoked.
 	cd "${ROOT_DIR}/libadore/external/" && make clean_cache
 
+.PHONY: clean_external 
+clean_external: ## clean all libadore external libraries
+	cd "${ROOT_DIR}/libadore/external/" && make clean
+
 
 .PHONY: static_checks
 static_checks: lint lizard cppcheck

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ test: set_env ## run libadore unit tests
 build_external: ## builds all libadore external libraries 
 	cd "${ROOT_DIR}/libadore/external/" && make
 
-.PHONY: clean_external 
-clean_external: ## clean all libadore external libraries
-	cd "${ROOT_DIR}/libadore/external/" && make clean
+.PHONY: clean_external_cache 
+clean_external_cache: ## clean all libadore external library cache located in /var/tmp. Note: This is never done automatically and must be manually invoked.
+	cd "${ROOT_DIR}/libadore/external/" && make clean_cache
 
 
 .PHONY: static_checks

--- a/README.md
+++ b/README.md
@@ -122,8 +122,15 @@ you would like to build in the `.gitmodules` file.
 > by modifying the `.gitmodules` and invoking 'git submodue update --init'.
 
 > **ℹ️ INFO:**
-> By default external libraries are not built. They are sourced as pre-compiled
-> docker images from docker.io.
+> By default external libraries are not built. They are sourced first from local
+> cache in /var/tmp/docker and seconds as pre-compiled docker images from docker.io.
+
+The external libraries cache is not deleted or cleaned automatically. In order
+to clean the external libriary cache located in `/var/tmp/docker` invoke the 
+provided target:
+```bash
+make clean_external_cache
+```
 
 ## License
 The source code and the accompanying material is licensed under the terms of the [EPL v2](https://www.eclipse.org/legal/epl-2.0/).

--- a/ci.env
+++ b/ci.env
@@ -17,7 +17,7 @@ build_artifacts=(
     "${build_directory}/install/lib/libmad.a"
     "${build_directory}/install/lib/libqpOASES.a"
     "${build_directory}/install/lib/libxodr.a"
-    "${build_directory}/${project}*.tar"
+    "${build_directory}/docker/${project}*.tar"
 )
 
 log_files=(

--- a/ci.env
+++ b/ci.env
@@ -17,7 +17,7 @@ build_artifacts=(
     "${build_directory}/install/lib/libmad.a"
     "${build_directory}/install/lib/libqpOASES.a"
     "${build_directory}/install/lib/libxodr.a"
-    "${build_directory}/docker/${project}*.tar"
+    "${build_directory}/${project}*.tar"
 )
 
 log_files=(

--- a/libadore.mk
+++ b/libadore.mk
@@ -56,7 +56,7 @@ clean_libadore: ## Clean libadore build artifacts
 
 .PHONY: clean_external_library_cache
 clean_external_library_cache: ## Clean/delete libadore system wide cache in /var/tmp/docker. Note: this is never done automatically and must be manually invoked. 
-	cd "${LIBADORE_MAKEFILE_PATH}" && make clean
+	cd "${LIBADORE_MAKEFILE_PATH}" && make clean_external_library_cache
 
 .PHONY: branch_libadore
 branch_libadore: ## Returns the current docker safe/sanitized branch for libadore

--- a/libadore.mk
+++ b/libadore.mk
@@ -54,6 +54,10 @@ test_libadore: ## run libadore unit tests
 clean_libadore: ## Clean libadore build artifacts
 	cd "${LIBADORE_MAKEFILE_PATH}" && make clean
 
+.PHONY: clean_external_library_cache
+clean_external_library_cache: ## Clean/delete libadore system wide cache in /var/tmp/docker. Note: this is never done automatically and must be manually invoked. 
+	cd "${LIBADORE_MAKEFILE_PATH}" && make clean
+
 .PHONY: branch_libadore
 branch_libadore: ## Returns the current docker safe/sanitized branch for libadore
 	@printf "%s\n" ${LIBADORE_TAG}

--- a/libadore/external/Makefile
+++ b/libadore/external/Makefile
@@ -162,6 +162,11 @@ clean:
 	(cd csaps-cpp && make clean) 2>/dev/null || true 
 	(cd xodr && make clean) 2>/dev/null || true 
 
+.PHONY: clean_cache
+clean_cache: 
+	rm "${EXTERNALS_DOCKER_ARCHIVE}" 2> /dev/null || true
+
+
 .PHONY: docker_publish
 docker_publish:
 	docker tag "${QPOASES_TAG}" "${DOCKER_REPOSITORY}:${QPOASES_PROJECT}_${QPOASES_VERSION}"

--- a/libadore/external/Makefile
+++ b/libadore/external/Makefile
@@ -32,11 +32,14 @@ CSAPS_CPP_TAG=${CSAPS_CPP_PROJECT}:${CSAPS_CPP_VERSION}
 
 DOCKER_REPOSITORY=andrewkoerner/adore
 
-EXTERNALS_DOCKER_ARCHIVE="/var/tmp/libadore_externals.tar"
+EXTERNALS_DOCKER_DIRECTORY=/var/tmp/docker
+EXTERNALS_DOCKER_ARCHIVE=${EXTERNALS_DOCKER_DIRECTORY}/libadore_externals.tar
 
 .PHONY: save_docker_images
 save_docker_images:
-	@docker save -o "${EXTERNALS_DOCKER_ARCHIVE}" "${QPOASES_TAG}" "${DLIB_TAG}" "${CATCH2_TAG}" "${OSQP_TAG}" "${XODR_TAG}"
+	@mkdir -p ${EXTERNALS_DOCKER_DIRECTORY} && \
+    docker save -o "${EXTERNALS_DOCKER_ARCHIVE}" "${QPOASES_TAG}" "${DLIB_TAG}" "${CATCH2_TAG}" "${OSQP_TAG}" "${XODR_TAG}" && \
+    chgrp -R docker ${EXTERNALS_DOCKER_DIRECTORY} && chmod -R 2775 ${EXTERNALS_DOCKER_DIRECTORY} || true
 
 .PHONY: load_docker_images
 load_docker_images:

--- a/libadore/external/README.md
+++ b/libadore/external/README.md
@@ -19,8 +19,15 @@ you would like to build in the `.gitmodules` file.
 
 > **ℹ️ INFO:**
 > By default external libraries are not built. They are sourced as pre-compiled
-> docker images from docker.io. 
+> docker images from docker.io and saved to a local system wide cache in
+> /var/tmp. 
 
+The external libraries cache is not deleted or cleaned automatically. In order
+to clean the external library cache located in `/var/tmp/docker` invoke the 
+provided target:
+```bash
+make clean_cache
+```
 ## Getting Started
 Docker and Make are required
 


### PR DESCRIPTION
In order to save bandwidth and docker API calls and under normal circumstances the libadore/externals libraries/submodules are not populated or built. On first build of libadore each externals build context is pulled from docker and saved to /var/tmp. On subsequent builds the docker context is loaded from `/var/tmp/docker` to prevent repeated docker api calls.

This PR fixes a bug where one user pulls the images and saves them to `/var/tmp/docker` and another user tries to access them.
The directory `/var/tmp/docker` is created on first-ever build of libadore on the system and the permissions are set to the group `docker`. Any member of the docker group can then subsequently read and write to `/var/tmp/docker`

This is documented in the readme as part of the PR, as well as, an explicit make target was added to advertise this cache and provide a means to delete/clean it.
```
make help
Usage: make <target>
clean_external_library_cache             Clean/delete libadore system wide cache in /var/tmp/docker. Note: this is never done automatically and must be manually invoked.
```